### PR TITLE
add group-by option in forget action

### DIFF
--- a/example.toml
+++ b/example.toml
@@ -28,6 +28,7 @@ keep-last =  3
 keep-hourly =  5
 keep-weekly = 10
 keep-monthly = 30
+group-by = "host,paths"
 # https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
 
 [check]

--- a/runrestic/config/schema.json
+++ b/runrestic/config/schema.json
@@ -71,7 +71,8 @@
         "keep-monthly": {"type": "integer"},
         "keep-yearly": {"type": "integer"},
         "keep-within": {"type": "integer"},
-        "keep-tag": {"type": "integer"}
+        "keep-tag": {"type": "integer"},
+        "group-by": {"type": "string"}
       }
     },
 

--- a/runrestic/restic/__init__.py
+++ b/runrestic/restic/__init__.py
@@ -84,6 +84,8 @@ class ResticRepository:
         for key, value in config.items():
             if key.startswith('keep-'):
                 cmd += ['--{key}'.format(key=key), str(value)]
+            if key == 'group-by':
+                cmd += ['--group-by', value]
 
         logger.debug(" ".join(cmd))
         try:


### PR DESCRIPTION
By default, restic use host & path as a way to group snapshots before applying forget policies.
https://restic.readthedocs.io/en/latest/060_forget.html#removing-snapshots-according-to-a-policy
As we are using runrestic to do our kubernetes statefulset backups, we spawn a runrestic pod each time we trigger a backup. So the host is always changing therefor it never remove any snapshot.

The goal of this PR is to allow the use of the --group-by option of forget action.